### PR TITLE
Import submodules automatically, like pygame does.

### DIFF
--- a/src/pygame_sdl2/__init__.py
+++ b/src/pygame_sdl2/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2014 Tom Rothamel <tom@rothamel.us>
+# Copyright 2014 Patrick Dawson <pat@dw.is>
 #
 # This software is provided 'as-is', without any express or implied
 # warranty.  In no event will the authors be held liable for any damages
@@ -15,3 +16,10 @@
 # 2. Altered source versions must be plainly marked as such, and must not be
 #    misrepresented as being the original software.
 # 3. This notice may not be removed or altered from any source distribution.
+
+import event
+import display
+
+def init():
+    event.init()
+    display.init()

--- a/test.py
+++ b/test.py
@@ -1,14 +1,11 @@
-import pygame_sdl2.display
-import pygame_sdl2.event
+import pygame_sdl2 as pygame
 from pygame_sdl2.locals import *
 
-pygame_sdl2.display.init()
-pygame_sdl2.event.init()
-
-pygame_sdl2.display.set_mode((200, 200))
+pygame.init()
+pygame.display.set_mode((200, 200))
 
 while True:
-    ev = pygame_sdl2.event.wait()
+    ev = pygame.event.wait()
 
     if ev.type == QUIT:
         break


### PR DESCRIPTION
Assuming we want transparent compatibility with pygame to the greatest extent possible. Similarly, the changes to test.py make comparing to pygame a little easier.
