### PR TITLE
process_namehint py3k fix

### DIFF
--- a/src/pygame_sdl2/image.pyx
+++ b/src/pygame_sdl2/image.pyx
@@ -47,10 +47,13 @@ cdef process_namehint(namehint):
     if not isinstance(namehint, bytes_):
         namehint = namehint.encode("ascii", "replace")
 
+    if not namehint:
+        return b''
+
     ext = os.path.splitext(namehint)[1]
-    if ext == '':
+    if not ext:
         ext = namehint
-    if ext[0] == '.':
+    if ext[0] == b'.':
         ext = ext[1:]
 
     return ext.upper()


### PR DESCRIPTION
Loading a targa image caused `process_namehint` to raise `IndexError` on line 53. 

This is because `process_namehint` got the string `'TGA'` from line 70. `splitext` returns `b''`, but in py3k `b'' != ''`, and finally `ext[0]` caused the `IndexError`.