### PR TITLE
Fix errors in Channel.play(sound).

### DIFF
--- a/src/pygame_sdl2/mixer.pyx
+++ b/src/pygame_sdl2/mixer.pyx
@@ -244,7 +244,7 @@ class Channel(object):
             raise error()
 
         with _lock:
-            self.current_sounds[self._cid] = sound
+            current_sounds[self.cid] = sound
 
     def stop(self):
         Mix_HaltChannel(self.cid)


### PR DESCRIPTION
Channel.play(sound) was throwing the following error:

```
  File "test_gui.py", line 80, in do_record_wav
    self.channel.play(sound, 0)
  File "pygame_sdl2/mixer.pyx", line 246, in pygame_sdl2.mixer.Channel.play (gen/pygame_sdl2.mixer.c:5041)
  File "pygame_sdl2/mixer.pyx", line 247, in pygame_sdl2.mixer.Channel.play (gen/pygame_sdl2.mixer.c:4993)
AttributeError: 'Channel' object has no attribute 'current_sounds'
```

This patch fixes that bug (and the related renaming of the `cid` attribute). After fixing the bug, I can verify that `Channel.play(sound)` correctly plays sound.