### PR TITLE
Fixed LayeredUpdates.get_sprites_at(pos) by passing a list of Rects

### DIFF
--- a/src/pygame_sdl2/sprite.py
+++ b/src/pygame_sdl2/sprite.py
@@ -785,7 +785,7 @@ class LayeredUpdates(AbstractGroup):
         """
         _sprites = self._spritelist
         rect = Rect(pos, (0, 0))
-        colliding_idx = rect.collidelistall(_sprites)
+        colliding_idx = rect.collidelistall([sprite.rect for sprite in _sprites])
         colliding = [_sprites[i] for i in colliding_idx]
         return colliding
 


### PR DESCRIPTION
I am fixing https://github.com/renpy/pygame_sdl2/issues/67 by passing a list of Rects instead of a list of Sprites to rect.collidelistall() in LayeredUpdates.get_sprites_at(pos) (method b. in my post).

If you prefer method a. (init a Rect from any object with a "rect" attribute), ask me and I'll modify rect.pyx instead.