### PR TITLE
fixed dead link for nightly builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Downloads
 
 Nightly builds are available from:
 
-http://nightly.renpy.org/pygame_sdl2/
+https://nightly.renpy.org/current/
 
 An official release will be coming to pypi shortly.
 


### PR DESCRIPTION
The link for nightly builds within the README 404's. Replaced it with https://nightly.renpy.org/current/.