### PR TITLE
remove deprecated use of subprocess.mswindows

### DIFF
--- a/test/test_utils/async_sub.py
+++ b/test/test_utils/async_sub.py
@@ -23,7 +23,7 @@ if sys.version_info >= (3,):
 else:
     null_byte = '\x00'
 
-if subprocess.mswindows:
+if sys.platform == 'win32':
     if sys.version_info >= (3,):
         # Test date should be in ascii.
         def encode(s):
@@ -134,7 +134,7 @@ class Popen(subprocess.Popen):
         getattr(self, which).close()
         setattr(self, which, None)
     
-    if subprocess.mswindows:
+    if sys.platform == 'win32':
         def kill(self):
             # Recipes
             #http://me.in-berlin.de/doc/python/faq/windows.html#how-do-i-emulate-os-kill-in-windows


### PR DESCRIPTION
starting with python3.5 this has been removed.