### PR TITLE
Fix build failure due to the removal of MIX_INIT_MODPLUG and the repl…

### DIFF
--- a/include/sdl2_mixer.pxd
+++ b/include/sdl2_mixer.pxd
@@ -18,10 +18,9 @@ cdef extern from "SDL_mixer.h" nogil:
     ctypedef enum MIX_InitFlags:
         MIX_INIT_FLAC
         MIX_INIT_MOD
-        MIX_INIT_MODPLUG
         MIX_INIT_MP3
         MIX_INIT_OGG
-        MIX_INIT_FLUIDSYNTH
+        MIX_INIT_MID
 
     int Mix_Init(int flags)
     void Mix_Quit()

--- a/src/pygame_sdl2/mixer.pyx
+++ b/src/pygame_sdl2/mixer.pyx
@@ -81,8 +81,8 @@ def init(frequency=22050, size=MIX_DEFAULT_FORMAT, channels=2, buffer=4096):
     if get_init() is not None:
         return
 
-    for flag in (MIX_INIT_FLAC, MIX_INIT_MOD, MIX_INIT_MODPLUG,
-                 MIX_INIT_MP3, MIX_INIT_OGG, MIX_INIT_FLUIDSYNTH):
+    for flag in (MIX_INIT_FLAC, MIX_INIT_MOD,
+                 MIX_INIT_MP3, MIX_INIT_OGG, MIX_INIT_MID):
 
         if Mix_Init(flag) != flag:
             errors.append("{}\n".format(SDL_GetError()))


### PR DESCRIPTION
…acement of

MIX_INIT_FLUIDSYNTH with MIX_INIT_MID in SDL2_MIXER 2.0.2. In this version the definitions look like this (SDL2/SDL_mixer.h)

typedef enum
{
    MIX_INIT_FLAC   = 0x00000001,
    MIX_INIT_MOD    = 0x00000002,
    MIX_INIT_MP3    = 0x00000008,
    MIX_INIT_OGG    = 0x00000010,
    MIX_INIT_MID    = 0x00000020
} MIX_InitFlags;
