### PR TITLE
Fix frozen programs crash due to missing json import

### DIFF
--- a/src/pygame_sdl2/__init__.py
+++ b/src/pygame_sdl2/__init__.py
@@ -106,6 +106,7 @@ try_import("joystick")
 try_import("mixer")
 try_import("mouse")
 try_import("power")
+try_import("render")
 try_import("transform")
 try_import("scrap")
 try_import("sprite")
@@ -127,10 +128,13 @@ def _optional_imports():
     import pygame_sdl2.mixer
     import pygame_sdl2.mouse
     import pygame_sdl2.power
+    import pygame_sdl2.render
     import pygame_sdl2.transform
     import pygame_sdl2.scrap
     import pygame_sdl2.sprite
     import pygame_sdl2.sysfont
+
+    import json  # this fixes a missing import error when freezing pygame_sdl2 programs that use the render module
 
 
 # Fill this module with locals.


### PR DESCRIPTION
If you try to freeze a pygame_sdl2 program right now using PyInstaller you get a crash on windows (and presumably other platforms) with a json import error. Adding an 'import json' fixes this crash and lets pygame_sdl2 support PyInstaller.

While I was in here I added two lines of optional imports for the render module in the same pattern as the other optional import modules - since they seemed to be missing. These are not essential to fix the crash and can be removed if they aren't wanted for some reason.