### PR TITLE
Adding readme advice for building on windows 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,28 @@ and then build and install using::
 This assumes you have installed a version of Visual Studio that is
 appropriate for the version of Python you are using.
 
+If you also want to install the python headers in a standard fashion
+to make an IDE's autocomplete work then you should try creating a
+python wheel. First grab the wheel package::
+
+    pip install wheel
+
+Then use this command to build your wheel::
+
+    python setup.py sdist bdist_wheel
+
+Finally, you will need to install your wheel from the dist
+sub-directory with pip. What it is called will depend on your version
+of python, the current version of the library and your platform.
+For example, here is a command to install a python 3.6 wheel,
+on 32bit windows::
+
+    pip install dist\pygame_sdl2-2.1.0-cp36-cp36m-win32.whl
+
+You will also need to delete any currently installed version of
+pygame_sdl2 from your Lib/site-packages directory to re-install
+this way.
+
 C Headers
 ^^^^^^^^^
 
@@ -151,6 +173,14 @@ function will be called. The following functions are exposed:
 
 * PySurface_AsSurface - Returns the SDL_Surface underlying a pygame_sdl2.Surface.
 * PySurface_New - Wraps an SDL_Surface in a new pygame_sdl2.Surface.
+
+Pygame incompatibility
+----------------------
+
+Pygame_sdl2 is designed as a complete replacement for pygame.
+
+If you try to use both the `pygame_sdl2` and `pygame` libraries in the same program
+you may encounter errors; such as library import failures in frozen programs.
 
 
 Contributing


### PR DESCRIPTION
Changes to the readme to give some additional build advice for windows and adds a section noting the incompatibility between pygame and pygame_sdl2.