### PR TITLE
py3: static submodules support

### DIFF
--- a/setuplib.py
+++ b/setuplib.py
@@ -260,9 +260,11 @@ def cython(name, source=[], libs=[], compile_if=True, define_macros=[]):
                 parent_module_identifier = parent_module.replace('.', '_')
                 with open(c_fn, 'r') as f:
                     ccode = f.read()
-                ccode = re.sub('Py_InitModule4\("([^"]+)"', 'Py_InitModule4("' + parent_module + '.\\1"', ccode)
-                ccode = re.sub('^__Pyx_PyMODINIT_FUNC init', '__Pyx_PyMODINIT_FUNC init' + parent_module_identifier + '_', ccode, 0, re.MULTILINE) # Cython 0.28.2
-                ccode = re.sub('^PyMODINIT_FUNC init', 'PyMODINIT_FUNC init' + parent_module_identifier + '_', ccode, 0, re.MULTILINE) # Cython 0.25.2
+                ccode = re.sub('Py_InitModule4\("([^"]+)"', 'Py_InitModule4("'+parent_module+'.\\1"', ccode)  # Py2
+                ccode = re.sub('(__pyx_moduledef.*?"){}"'.format(re.escape(split_name[-1])), '\\1'+'.'.join(split_name)+'"', ccode, flags=re.DOTALL)  # Py3
+                ccode = re.sub('^__Pyx_PyMODINIT_FUNC init', '__Pyx_PyMODINIT_FUNC init'+parent_module_identifier+'_', ccode, 0, re.MULTILINE)  # Py2 Cython 0.28+
+                ccode = re.sub('^__Pyx_PyMODINIT_FUNC PyInit_', '__Pyx_PyMODINIT_FUNC PyInit_'+parent_module_identifier+'_', ccode, 0, re.MULTILINE)  # Py3 Cython 0.28+
+                ccode = re.sub('^PyMODINIT_FUNC init', 'PyMODINIT_FUNC init'+parent_module_identifier+'_', ccode, 0, re.MULTILINE)  # Py2 Cython 0.25.2
                 with open(c_fn, 'w') as f:
                     f.write(ccode)
 


### PR DESCRIPTION
RenPyWeb is compiled full-static, including Python modules, for better performance and to avoid limitations with (experimental) dynamic loading in Emscripten.

Python doesn't support static submodules natively, and neither does Cython.
On the Python front things are improving a bit as we can now add start-up Py3 code rather than patch the C code. But we still need to include the module path in the Cython C output.

This complements 98d4418ea4fd3e92dc32d95293b7d181e13b3601 to handle Python 3 code generated by cython.
