### PR TITLE
Fix file handle leak when file-like object is subfile

### DIFF
--- a/src/pygame_sdl2/rwobject.pyx
+++ b/src/pygame_sdl2/rwobject.pyx
@@ -248,6 +248,8 @@ cdef SDL_RWops *to_rwops(filelike, mode="rb") except NULL:
                 rv.type = 0
                 rv.hidden.unknown.data1 = <void *> sf
 
+                filelike.close()
+
                 return rv
 
         except AttributeError:


### PR DESCRIPTION
When file-like object is passed to `RWopsFromPython`, the file handle should be closed with `SDL_RWops`.  
However, the `SubFile` optimization bypasses this and creates its own `SDL_RWops` based on the `SubFile` class information, so the `SubFile` class should be closed as soon as it is passed into `RWopsFromPython`.  
