### PR TITLE
Add JPEG-XL, AVIF support

### DIFF
--- a/include/sdl2_image.pxd
+++ b/include/sdl2_image.pxd
@@ -6,6 +6,8 @@ cdef extern from "SDL_image.h" nogil:
         IMG_INIT_PNG
         IMG_INIT_TIF
         IMG_INIT_WEBP
+        IMG_INIT_JXL
+        IMG_INIT_AVIF
 
     int IMG_Init(int flags)
     void IMG_Quit()

--- a/src/pygame_sdl2/image.pyx
+++ b/src/pygame_sdl2/image.pyx
@@ -33,7 +33,7 @@ cdef int image_formats = 0
 
 def init():
     global image_formats
-    image_formats = IMG_Init(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF | IMG_INIT_WEBP)
+    image_formats = IMG_Init(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF | IMG_INIT_WEBP | IMG_INIT_JXL | IMG_INIT_AVIF)
     if image_formats == 0:
         raise error()
 

--- a/src/pygame_sdl2/image.pyx
+++ b/src/pygame_sdl2/image.pyx
@@ -32,12 +32,24 @@ import pygame_sdl2
 cdef int image_formats = 0
 
 def init():
+    # Attempt to initialize everything. Only fail loudly if all formats fail
     global image_formats
     image_formats = IMG_Init(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF | IMG_INIT_WEBP | IMG_INIT_JXL | IMG_INIT_AVIF)
     if image_formats == 0:
         raise error()
 
 init()
+
+# Make it possible for python to check individual formats
+INIT_JPG = IMG_INIT_JPG
+INIT_PNG = IMG_INIT_PNG
+INIT_TIF = IMG_INIT_TIF
+INIT_WEBP = IMG_INIT_WEBP
+INIT_JXL = IMG_INIT_JXL
+INIT_AVIF = IMG_INIT_AVIF
+
+def has_init(int flags):
+    return (flags & image_formats) == flags
 
 def quit(): # @ReservedAssignment
     IMG_Quit()


### PR DESCRIPTION
Both are available starting with SDL2_image 2.6.0, but must be explicitly enabled at build-time.

Also let python query successful initialization of specific formats. I'm unsure if this was originally intended, but pygame_sdl2.image.init() will only fail if ALL requested formats fail to initialize. This gives renpy the opportunity to check if any actually used formats are required. I'm open to suggestions as to better ways of handling missing formats in SDL2_image. Unfortunately, it is rather cumbersome to query support of formats that don't have to be initialized, so this was omitted (they are enabled in the default configuation anyway). 

Fixes #136 