### PR TITLE
Fix webaudio broken by RWops PR

### DIFF
--- a/src/pygame_sdl2/rwobject.pyx
+++ b/src/pygame_sdl2/rwobject.pyx
@@ -467,9 +467,10 @@ cdef class RWopsImpl(object):
         return ctypes.c_void_p(<uintptr_t> self.ops)
 
 class RWops(io.RawIOBase):
-    def __init__(self):
+    def __init__(self, name=None):
         io.RawIOBase.__init__(self)
         self._holder = RWopsImpl()
+        self.name = name
 
     # Implemented class: io.IOBase
 
@@ -559,7 +560,7 @@ def RWops_from_file(name, mode="rb"):
         if rw == NULL:
             raise IOError("Could not open {!r}: {}".format(name, SDL_GetError()))
 
-        rv = RWops()
+        rv = RWops(name)
         (<RWopsImpl>rv._holder).set_rwops(rw)
 
         return rv


### PR DESCRIPTION
Since https://github.com/renpy/renpy/pull/3423 has been merged, [`webaudio.play()`](https://github.com/renpy/renpy/blob/a4b1172883cf4613fd8ddb70231f4834f0e0ad5b/renpy/audio/webaudio.py#L56) is broken as the `file` argument is now a `RWops` object with no way to retrieve the location of the underlying resource file. This PR simply adds a `name` attribute to `RWops` to store the file location to match the definition of [`io.FileIO`](https://docs.python.org/3/library/io.html#io.FileIO.name) (which is what `webaudio` expects).

Setting this attribute only from `RWops_from_file()` seems to fix the issue, but maybe it should be set in other locations where a `RWops` object is created as well.