### PR TITLE
Support virtual input mode

### DIFF
--- a/src/pygame_sdl2/event.pyx
+++ b/src/pygame_sdl2/event.pyx
@@ -461,6 +461,9 @@ def get_blocked(t):
 def set_grab(on):
     SDL_SetWindowGrab(main_window.window, on)
 
+    if SDL_ShowCursor(SDL_QUERY) == SDL_DISABLE:
+        SDL_SetRelativeMouseMode(on)
+
 def get_grab():
     return SDL_GetWindowGrab(main_window.window)
 

--- a/src/pygame_sdl2/mouse.pyx
+++ b/src/pygame_sdl2/mouse.pyx
@@ -17,6 +17,7 @@
 # 3. This notice may not be removed or altered from any source distribution.
 
 from sdl2 cimport *
+from pygame_sdl2.display cimport main_window
 from pygame_sdl2.surface cimport Surface
 
 def init():
@@ -54,7 +55,9 @@ def set_pos(pos):
 
 def set_visible(visible):
     SDL_ShowCursor(1 if visible else 0)
-    pass
+
+    if SDL_GetWindowGrab(main_window.window) == SDL_ENABLE:
+        SDL_SetRelativeMouseMode(SDL_FALSE if visible else SDL_TRUE)
 
 def get_focused():
     return SDL_GetMouseFocus() != NULL


### PR DESCRIPTION
Between SDL1.2 and SDL2 the method for switching to relative mouse mode changed, breaking pygame's virtual input mode. This patch is based on a [change](https://github.com/pygame/pygame/pull/1457/files) in pygame proper from 2019 made to address this [issue](https://github.com/pygame/pygame/issues/1210).

**Current behaviour**

Despite using `pygame.event.set_grab(True)` and `pygame.mouse.set_visible(False)` at the same time, the (hidden) cursor is limited to the confines of the window and the relative mouse movement values stop progressing at that point.

**Expected behaviour / with this patch**

Using `pygame.event.set_grab(True)` and `pygame.mouse.set_visible(False)` at the same time acitvates "virtual input" mode as documented by `pygame` near the top of [this page](https://www.pygame.org/docs/ref/mouse.html). The (hidden) cursor and its reported position are still (correctly) limited to the confines of the window as before, *however the relative mouse movement values no longer stop progressing at the window edge.*

**Benefits**

This allows advanced CDDs to enter virtual input mode in order to facilitate seamless mouse-controlled panning, dragging, etc. It also becomes possible to simulate mouse sensitivity and acceleration changes by adjusting the relative movement values before accumulating them.

<details><summary>Test game (click and hold to switch into virtual input mode)</summary>

```rpy
label main_menu:
    $ _confirm_quit = False
    return


label start:
    scene black
    call screen test()
    return


screen test():
    grid 2 3:
        align (.5, .2)
        spacing 10
        xsize .4

        text 'real pos' xalign 1.
        text '[data["pos"]]'
        text 'most recent delta' xalign 1.
        text '[data["mov"]]'
        text 'virtual pos' xalign 1.
        if 'vir' in data:
            text '[data["vir"]]' color '7fa'
        else:
            text 'off'

    add MousePosReporter()


init python:
    import collections
    import pygame

    v = collections.namedtuple('vector', 'x y')
    v.__iadd__ = lambda self, o: v(self[0] + o[0], self[1] + o[1])

    data = _dict(pos=None, mov=None)


    def virtual_input(toggle):
        # per https://www.pygame.org/docs/ref/mouse.html
        pygame.mouse.set_visible(not toggle)
        pygame.event.set_grab(toggle)


    class MousePosReporter(Null):
        def event(self, ev, x, y, st):
            if ev.type == pygame.MOUSEMOTION:
                data['pos'] = x, y
                data['mov'] = ev.rel # same value as from pygame.mouse.get_rel()
                if 'vir' in data:
                    data['vir'] += ev.rel
                renpy.restart_interaction()

            elif ev.type == pygame.MOUSEBUTTONDOWN and ev.button == 1:
                virtual_input(True)
                data['end'] = data['vir'] = v(x, y)

            elif ev.type == pygame.MOUSEBUTTONUP and ev.button == 1:
                virtual_input(False)
                del data['vir']
                renpy.set_mouse_pos(*data['end'])

            else:
                return None

            renpy.restart_interaction()
            raise renpy.display.core.IgnoreEvent
```
</details>

Tested successfully on Ubuntu 22.04 using `fix` branches plus this change.