### PR TITLE
Make scrap.put() work on Web

### DIFF
--- a/src/pygame_sdl2/scrap.pyx
+++ b/src/pygame_sdl2/scrap.pyx
@@ -23,6 +23,11 @@ from pygame_sdl2.locals import SCRAP_TEXT
 
 from pygame_sdl2.compat import bytes_
 
+try:
+    import emscripten
+except ImportError:
+    emscripten = None
+
 def init():
     pass
 
@@ -44,6 +49,14 @@ def get_types():
 def put(type, data):
     if type != SCRAP_TEXT:
         raise error("Not implemented.")
+
+    if emscripten is not None:
+        # SDL_SetClipboardText() is not implemented for Web
+        import re
+        text = data.decode('utf-8')
+        script = 'navigator.clipboard.writeText(`%s`)' % (re.sub(r'([\\`$])', r'\\\1', text),)
+        emscripten.run_script(script)
+        return
 
     data = bytes_(data)
 


### PR DESCRIPTION
This should make it possible to copy text to clipboard from Ren'Py games. It would be better to implement clipboard support in emscripten/SDL2 but there seems to be [low interest](https://github.com/emscripten-core/emscripten/issues/6377) for that.

As usual with Web browsers, the copy will not be allowed if it is not associated with a user interaction. It seems to work correctly when clicking on the "Copy" buttons of the error screen at least (and Ctrl-C from the console).

Implementing `scrap.get()` on Web is more complex though, because paste events are only sent to focused editable elements (not the canvas then) and the only alternative is to ask for a clipboard read permission. I don't like the idea of letting a website read my clipboard whenever it wants just because it hosts a Ren'Py game, so I won't be the one implementing that.