### PR TITLE
Added .gitmodules for fetching submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pygame_sdl2_windeps"]
+    path = pygame_sdl2_windeps
+    url = https://github.com/renpy/pygame_sdl2_windeps.git


### PR DESCRIPTION
Fix malformed submodules setup by adding `.gitmodules` file. Now submodules can be fetched with `git submodule update --init`.